### PR TITLE
Additional Test Coverage For Portfolio Tools

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -10,8 +10,10 @@ from six.moves.urllib.parse import unquote
 from six.moves.urllib.request import getproxies
 from six.moves import input
 
-import Robinhood.exceptions as RH_exception
-
+if six.PY3:
+    import Robinhood.exceptions as RH_exception
+else:
+    import exceptions as RH_exception
 
 class Bounds(Enum):
     """enum for bounds in `historicals` endpoint"""
@@ -84,7 +86,8 @@ class Robinhood:
 
     auth_token = None
 
-    logger = logging.getLogger('Robinhood').addHandler(logging.NullHandler())
+    logger = logging.getLogger('Robinhood')
+    logger.addHandler(logging.NullHandler())
 
     ##############################
     #Logging in and initializing
@@ -748,3 +751,6 @@ class Robinhood:
         order = Order.LIMIT
         trigger = Trigger.STOP
         return self.place_order(instrument, quantity, price, transaction, trigger, order, time_in_force)
+
+class TestException(Exception):
+    pass

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -751,6 +751,3 @@ class Robinhood:
         order = Order.LIMIT
         trigger = Trigger.STOP
         return self.place_order(instrument, quantity, price, transaction, trigger, order, time_in_force)
-
-class TestException(Exception):
-    pass

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -504,7 +504,7 @@ class Robinhood:
         """Returns the user's portfolio data."""
         req = self.session.get(self.endpoints['portfolios'])
         req.raise_for_status()
-        return req.json()
+        return req.json()['results'][0]
 
     def adjusted_equity_previous_close(self):
         """wrapper for portfolios
@@ -544,7 +544,10 @@ class Robinhood:
         get `extended_hours_equity` value
 
         """
-        return float(self.portfolios()['extended_hours_equity'])
+        try:
+            return float(self.portfolios()['extended_hours_equity'])
+        except TypeError:
+            return None
 
     def extended_hours_market_value(self):
         """wrapper for portfolios
@@ -552,7 +555,10 @@ class Robinhood:
         get `extended_hours_market_value` value
 
         """
-        return float(self.portfolios()['extended_hours_market_value'])
+        try:
+            return float(self.portfolios()['extended_hours_market_value'])
+        except TypeError:
+            return None
 
     def last_core_equity(self):
         """wrapper for portfolios

--- a/Robinhood/__init__.py
+++ b/Robinhood/__init__.py
@@ -4,6 +4,4 @@ if six.PY3:
     from Robinhood.Robinhood import Robinhood
 else:
     from Robinhood import Robinhood
-    import Robinhood.RobinhoodException as RobinhoodException
-    import Robinhood.LoginFailed as LoginFailed
-    import TwoFactorRequired.TwoFactorRequired as TwoFactorRequired
+    import exceptions as RH_exception

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,6 @@ Testing is easy:
 * Some tests are squishy due to update windows, may require retry loops
     * [flaky](https://pypi.python.org/pypi/flaky) has been included to retry weird tests
 * **DO NOT TEST DURING TRADING HOURS** will assert on price data
-* `test_portfolio.py` does not fail gracefully w/o valid passwords
 
 ## TODO
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,6 +18,8 @@ Testing is easy:
 * `@pytest.mark.incremental` allows for sequence/group tests [more info](http://doc.pytest.org/en/latest/example/simple.html#incremental-testing-test-steps)
 * Some tests are squishy due to update windows, may require retry loops
     * [flaky](https://pypi.python.org/pypi/flaky) has been included to retry weird tests
+* **DO NOT TEST DURING TRADING HOURS** will assert on price data
+* `test_portfolio.py` does not fail gracefully w/o valid passwords
 
 ## TODO
 

--- a/tests/test_getdata.py
+++ b/tests/test_getdata.py
@@ -152,7 +152,7 @@ class TestFundamentalsHelpers:
             self.test_ticker,
             config
         )
-
+    @flaky
     def test_validate_fundamental(self):
         """validate fetcher"""
         data = self.rh_obj.get_fundamentals(self.test_ticker)

--- a/tests/test_getdata.py
+++ b/tests/test_getdata.py
@@ -1,5 +1,6 @@
 from os import path
 from datetime import datetime
+import six
 
 import pytest
 from flaky import flaky
@@ -7,6 +8,8 @@ import requests
 
 from Robinhood import Robinhood
 import helpers
+if six.PY2:
+    from Robinhood import RH_exception
 
 HERE = path.abspath(path.dirname(__file__))
 ROOT = path.dirname(HERE)

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -71,7 +71,7 @@ class TestPortfolioMethods:
         global TEST_PORTFOLIO
         if not LOGIN_OK:
             print('Unable to test Portfolio without auth')
-            assert False
+            pytest.xfail('cannot test without valid user/passwd')
         print(self.rh_obj.auth_token)
         data = self.rh_obj.portfolios()
         #TODO validate data
@@ -125,6 +125,8 @@ class TestPortfolioMethods:
 
 def test_logout(config=CONFIG):
     """make sure logout works"""
+    if not LOGIN_OK:
+        pytest.xfail('cannot test without valid user/passwd')
     rh_obj = Robinhood()
     assert rh_obj.login(
         username=config.get('LOGIN', 'username'),
@@ -137,6 +139,8 @@ def test_logout(config=CONFIG):
 
 def test_bad_logout():
     """logout without logging in"""
+    if not LOGIN_OK:
+        pytest.xfail('cannot test without valid user/passwd')
     rh_obj = Robinhood()
     with pytest.warns(UserWarning):
         req = rh_obj.logout()

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -58,14 +58,14 @@ class TestPortfolioMethods:
     NOTE: reliant on an active account to pull data from
 
     """
+    rh_obj = Robinhood()
     try:
-        rh_obj = Robinhood()
         rh_obj.login(
             username=CONFIG.get('LOGIN', 'username'),   #NOTE: py.test fails w/o password
             password=CONFIG.get('LOGIN', 'password')
         )
     except Exception:
-        rh_obj = None
+        pass
     def test_portfolios(self):
         """check `portfolio` method"""
         global TEST_PORTFOLIO

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -58,11 +58,14 @@ class TestPortfolioMethods:
     NOTE: reliant on an active account to pull data from
 
     """
-    rh_obj = Robinhood()
-    rh_obj.login(
-        username=CONFIG.get('LOGIN', 'username'),   #NOTE: py.test fails w/o password
-        password=CONFIG.get('LOGIN', 'password')
-    )
+    try:
+        rh_obj = Robinhood()
+        rh_obj.login(
+            username=CONFIG.get('LOGIN', 'username'),   #NOTE: py.test fails w/o password
+            password=CONFIG.get('LOGIN', 'password')
+        )
+    except Exception:
+        rh_obj = None
     def test_portfolios(self):
         """check `portfolio` method"""
         global TEST_PORTFOLIO

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,11 +1,14 @@
 from os import path
 from datetime import datetime
+import six
 
 import pytest
 from flaky import flaky
 
 from Robinhood import Robinhood
 import Robinhood.exceptions as RH_exception
+if six.PY2:
+    from Robinhood import RH_exception
 
 import helpers
 
@@ -57,7 +60,7 @@ class TestPortfolioMethods:
     """
     rh_obj = Robinhood()
     rh_obj.login(
-        username=CONFIG.get('LOGIN', 'username'),
+        username=CONFIG.get('LOGIN', 'username'),   #NOTE: py.test fails w/o password
         password=CONFIG.get('LOGIN', 'password')
     )
     def test_portfolios(self):

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -81,47 +81,58 @@ class TestPortfolioMethods:
     def test_validate_adjusted_equity(self):
         """test `adjusted_equity_previous_close` method"""
         value = self.rh_obj.adjusted_equity_previous_close()
-        assert value == TEST_PORTFOLIO['adjusted_equity_previous_close']
+        assert isinstance(value, float)
+        assert format(value, '.4f') == TEST_PORTFOLIO['adjusted_equity_previous_close']
 
     def test_validate_equity(self):
         """test `equity` method"""
         value = self.rh_obj.equity()
-        assert value == TEST_PORTFOLIO['equity']
+        assert isinstance(value, float)
+        assert format(value, '.4f') == TEST_PORTFOLIO['equity']
 
     def test_equity_previous_close(self):
         """test `equity_previous_close` method"""
         value = self.rh_obj.equity_previous_close()
-        assert value == TEST_PORTFOLIO['equity_previous_close']
+        assert isinstance(value, float)
+        assert format(value, '.4f') == TEST_PORTFOLIO['equity_previous_close']
 
     def test_excess_margin(self):
-        """test `excesss_margin` method"""
-        value = self.rh_obj.excesss_margin()
-        assert value == TEST_PORTFOLIO['excesss_margin']
+        """test `excess_margin` method"""
+        value = self.rh_obj.excess_margin()
+        assert isinstance(value, float)
+        assert format(value, '.4f') == TEST_PORTFOLIO['excess_margin']
 
     def test_ex_hours_equity(self):
         """test `extended_hours_equity method"""
         value = self.rh_obj.extended_hours_equity()
-        assert value == TEST_PORTFOLIO['extended_hours_equity']
+        assert isinstance(value, float) or (value is None)
+        if value:
+            assert format(value, '.4f') == TEST_PORTFOLIO['extended_hours_equity']
 
     def test_ex_hours_market_value(self):
         """test `extended_hours_market_value` method"""
         value = self.rh_obj.extended_hours_market_value()
-        assert value == TEST_PORTFOLIO['extended_hours_market_value']
+        assert isinstance(value, float) or (value is None)
+        if value:
+            assert format(value, '.4f') == TEST_PORTFOLIO['extended_hours_market_value']
 
     def test_last_core_equity(self):
         """test `last_core_equity` method"""
         value = self.rh_obj.last_core_equity()
-        assert value == TEST_PORTFOLIO['last_core_equity']
+        assert isinstance(value, float)
+        assert format(value, '.4f') == TEST_PORTFOLIO['last_core_equity']
 
     def test_last_core_market_value(self):
         """test `last_core_market_value` method"""
         value = self.rh_obj.last_core_market_value()
-        assert value == TEST_PORTFOLIO['last_core_market_value']
+        assert isinstance(value, float)
+        assert format(value, '.4f') == TEST_PORTFOLIO['last_core_market_value']
 
     def test_market_value(self):
         """test `market_value` method"""
         value = self.rh_obj.market_value()
-        assert value == TEST_PORTFOLIO['market_value']
+        assert isinstance(value, float)
+        assert format(value, '.4f') == TEST_PORTFOLIO['market_value']
 
 def test_logout(config=CONFIG):
     """make sure logout works"""


### PR DESCRIPTION
* Validated py2 coverage
* Added `TypeError` catches for `"extended*"` portfolio keys
* Added type validation to test
* Fixed test-run issue with no login creds

Remaining TODO:
* Test `news`, `dividends`, and `orders` wrappers
* Test `positions` tools